### PR TITLE
fix: handle null values as well as undefined

### DIFF
--- a/src/JSONPathQuery.ts
+++ b/src/JSONPathQuery.ts
@@ -40,10 +40,12 @@ const sortOperations = (ops: Operation[]): Operation[] =>
  */
 const removeEmpty = (obj: any) => {
   Object.keys(obj).forEach((key) => {
-    // Get this value and its type
+    // Get this value
     const value = obj[key];
-    const type = typeof value;
-    if (type === 'object') {
+    if (value == null) {
+      // Remove null/undefined values
+      delete obj[key];
+    } else if (typeof value === 'object') {
       // Recurse
       removeEmpty(value);
       // If it's an object without keys, delete
@@ -58,9 +60,6 @@ const removeEmpty = (obj: any) => {
           }
         }
       }
-    } else if (type === 'undefined') {
-      // Undefined, remove it
-      delete obj[key];
     }
   });
 };

--- a/src/test/unit.test.ts
+++ b/src/test/unit.test.ts
@@ -1,7 +1,8 @@
-import { suite, test } from 'mocha';
 import { expect } from 'chai';
-import JSONPathQuery, { Operation, checkValidJsonPath } from '../JSONPathQuery';
-import { simpleDocument, arrayDocument } from './fixture';
+import { suite, test } from 'mocha';
+
+import JSONPathQuery, { checkValidJsonPath, Operation } from '../JSONPathQuery';
+import { arrayDocument, simpleDocument } from './fixture';
 
 suite('TM Forum Examples - Fields', () => {
   test('Return channel name + root id and href', () => {
@@ -495,9 +496,7 @@ suite('TM Forum Examples - Filter', () => {
         path: '$[?(@.relatedEntity[?(@.id==3474)])]',
       },
     ];
-    const expected = [
-      arrayDocument[1],
-    ];
+    const expected = [arrayDocument[1]];
     const result = JSONPathQuery.query(arrayDocument, query);
     expect(result).to.eql(expected);
   });
@@ -718,5 +717,26 @@ suite('Test jsonpath expression validation', () => {
     const jsonpathExpression = 'id,href';
     const valid = checkValidJsonPath(jsonpathExpression);
     expect(valid).to.eql(true);
+  });
+});
+
+suite('Documents containing null/undefined values', () => {
+  test('remove empty objects', () => {
+    const document = {
+      foo: 'foo',
+      bar: undefined,
+      baz: null,
+    };
+    const query: Operation[] = [
+      {
+        op: 'fields',
+        path: 'foo,bar,baz',
+      },
+    ];
+    const expected = {
+      foo: 'foo',
+    };
+    const result = JSONPathQuery.query(document, query);
+    expect(result).to.eql(expected);
   });
 });


### PR DESCRIPTION
Since (typeof null === "object"), the removeEmpty function was attempting to recurse through null keys, causing it to crash. Use the more general-purpose check (value == null), which handles null and undefined.